### PR TITLE
Feature: Agregar reglas al linter para quitar warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,16 @@ module.exports = {
         "prettier/prettier": ["error", {}, { usePrettierrc: true }], // Use our .prettierrc file as source
         "@typescript-eslint/explicit-module-boundary-types": ["error"],
         "@typescript-eslint/no-explicit-any": ["error"],
-        "@typescript-eslint/no-unused-vars": ["error"]
+        "@typescript-eslint/no-unused-vars": ["error"],
+        "@typescript-eslint/explicit-function-return-type": [
+            "error",
+            {
+                allowExpressions: false,
+                allowTypedFunctionExpressions: true,
+                allowHigherOrderFunctions: true,
+                allowDirectConstAssertionInArrowFunctions: true,
+                allowConciseArrowFunctionExpressionsStartingWithVoid: true
+            }
+        ]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,8 +27,12 @@ module.exports = {
         "plugin:@typescript-eslint/recommended",
         "prettier/@typescript-eslint"
     ],
+    plugins: ["@typescript-eslint"],
     rules: {
         "react/jsx-sort-props": 2,
-        "prettier/prettier": ["error", {}, { usePrettierrc: true }] // Use our .prettierrc file as source
+        "prettier/prettier": ["error", {}, { usePrettierrc: true }], // Use our .prettierrc file as source
+        "@typescript-eslint/explicit-module-boundary-types": ["error"],
+        "@typescript-eslint/no-explicit-any": ["error"],
+        "@typescript-eslint/no-unused-vars": ["error"]
     }
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyledButton } from "./styles";
 import { IButton } from "./types";
 
-const Button: React.FunctionComponent<IButton> = ({ children, variant, styles }: IButton) => {
+const Button: React.FC<IButton> = ({ children, variant, styles }: IButton) => {
     return (
         <StyledButton styles={styles} variant={variant}>
             {children}

--- a/src/components/Button/styles.tsx
+++ b/src/components/Button/styles.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled, { css, FlattenSimpleInterpolation } from "styled-components";
 import { IButton } from "./types";
 import { theme, fontSizes } from "../../common/styles";
 
@@ -13,8 +13,8 @@ export const StyledButton = styled.button<IButton>`
     min-width: 243px;
     height: 48px;
     cursor: pointer;
-    ${({ variant }) => variants[variant]}
-    ${({ styles }) => styles}
+    ${({ variant }): FlattenSimpleInterpolation => variants[variant]}
+    ${({ styles }): string | undefined => styles}
      
       &:hover {
         opacity: 0.6;

--- a/src/components/ButtonSocial/icon.tsx
+++ b/src/components/ButtonSocial/icon.tsx
@@ -1,5 +1,3 @@
-import react from "react";
-
 export const Icons = [
     //facebook
     {

--- a/src/components/ButtonSocial/index.tsx
+++ b/src/components/ButtonSocial/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { StyledParagraph, StyledList, StyledItemList, StyledSvg } from "./styles";
 import { Icons } from "./icon";
-import { ISocialLogins } from "./types";
 
-const SocialLogins: React.FunctionComponent<ISocialLogins> = (text: ISocialLogins) => {
+const SocialLogins: React.FC<{ text: string }> = (text) => {
     return (
         <>
             <StyledParagraph>{text}</StyledParagraph>

--- a/src/components/ButtonSocial/index.tsx
+++ b/src/components/ButtonSocial/index.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { StyledParagraph, StyledList, StyledItemList, StyledSvg } from "./styles";
 import { Icons } from "./icon";
+import { ISocialLogins } from "./types";
 
-const SocialLogins = ({ text }: any) => {
+const SocialLogins: React.FunctionComponent<ISocialLogins> = (text: ISocialLogins) => {
     return (
         <>
             <StyledParagraph>{text}</StyledParagraph>

--- a/src/components/ButtonSocial/types.ts
+++ b/src/components/ButtonSocial/types.ts
@@ -1,0 +1,3 @@
+export interface ISocialLogins {
+    text: string;
+}

--- a/src/components/ButtonSocial/types.ts
+++ b/src/components/ButtonSocial/types.ts
@@ -1,3 +1,0 @@
-export interface ISocialLogins {
-    text: string;
-}

--- a/src/components/Carousel/DotsSlider/index.tsx
+++ b/src/components/Carousel/DotsSlider/index.tsx
@@ -16,7 +16,7 @@ const DotsSlider: React.FC<IDotsSlider> = ({
                     <StyledDot
                         active={activeTabIndex === index}
                         key={eachObj.id}
-                        onClick={() => handleClick(index)}></StyledDot>
+                        onClick={(): void => handleClick(index)}></StyledDot>
                 );
             })}
         </StyledUl>

--- a/src/components/Carousel/DotsSlider/styles.tsx
+++ b/src/components/Carousel/DotsSlider/styles.tsx
@@ -3,13 +3,13 @@ import { colors } from "../../../common/styles/index";
 
 const StyledDot = styled.button<{ active: boolean }>`
     padding: 0;
-    height: ${({ active }) => (active ? "8px" : "12px")};
-    width: ${({ active }) => (active ? "30px" : "14px")};
+    height: ${({ active }): string => (active ? "8px" : "12px")};
+    width: ${({ active }): string => (active ? "30px" : "14px")};
     border-radius: 10px;
     border: none;
     margin: 0 20px;
-    background-color: ${({ active }) => (active ? colors.orange : colors.lightOrange)};
-    transition: ${({ active }) => (active ? "2s" : "1s")} ease;
+    background-color: ${({ active }): string => (active ? colors.orange : colors.lightOrange)};
+    transition: ${({ active }): string => (active ? "2s" : "1s")} ease;
     cursor: pointer;
 `;
 

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -13,9 +13,7 @@ import { ICarousel } from "./types";
 const Carousel: React.FC<ICarousel> = ({ click, carouselData }: ICarousel) => {
     const [activeTabIndex, setActiveTabIndex] = useState(0);
 
-    const changeActiveTabHandler = (index: number) => {
-        return setActiveTabIndex(index);
-    };
+    const changeActiveTabHandler = (index: number): void => setActiveTabIndex(index);
 
     return (
         <main id="carousel">
@@ -26,7 +24,7 @@ const Carousel: React.FC<ICarousel> = ({ click, carouselData }: ICarousel) => {
                 handleClick={changeActiveTabHandler}
             />
             {activeTabIndex === carouselData.length - 1 ? (
-                <Button onClick={() => click()} variant={variantType.PRIMARY}>
+                <Button onClick={(): void => click()} variant={variantType.PRIMARY}>
                     Continuar
                 </Button>
             ) : null}

--- a/src/components/Carousel/styles.tsx
+++ b/src/components/Carousel/styles.tsx
@@ -2,12 +2,12 @@ import styled from "styled-components";
 import { fonts } from "../../common/styles/index";
 
 const StyledLi = styled.li<{ active: boolean }>`
-    z-index: ${(props) => (props.active ? "0" : "-10")};
-    opacity: ${(props) => (props.active ? "1" : "0")};
+    z-index: ${(props): string => (props.active ? "0" : "-10")};
+    opacity: ${(props): string => (props.active ? "1" : "0")};
     transition: 0.5s cubic-bezier(0, 0.84, 0.81, 1.01);
     overflow: hidden;
-    position: ${(props) => (props.active ? "relative" : "absolute")};
-    top: ${(props) => (props.active ? "0" : "-30px")};
+    position: ${(props): string => (props.active ? "relative" : "absolute")};
+    top: ${(props): string => (props.active ? "0" : "-30px")};
 
     list-style: none;
     width: 100%;

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React from "react";
 
 // Styled-components
 import { StyledImageResponsive } from "./styles";

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -6,7 +6,7 @@ import { StyledImageResponsive } from "./styles";
 // Others
 import { IImage } from "./types";
 
-const Image: React.FunctionComponent<IImage> = ({ src, alt }: IImage) => {
+const Image: React.FC<IImage> = ({ src, alt }: IImage) => {
     return <StyledImageResponsive alt={alt} src={src} />;
 };
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyledInput, StyledImg, StyledInputContainer, StyledIconBox } from "./styles";
 import { IInput } from "./types";
 
-const Input: React.FunctionComponent<IInput> = ({
+const Input: React.FC<IInput> = ({
     type,
     name,
     id,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,8 +3,10 @@ import { Switch, Route } from "react-router-dom";
 import Splash from "../pages/Splash";
 import Routes from "../routes/routes";
 
-const Layout = () => {
+const Layout: React.FunctionComponent = () => {
+    // eslint-disable-next-line
     const getRoutes = (routes: any): ReactNode => {
+        // eslint-disable-next-line
         return routes.map((route: any) => {
             return (
                 <Route

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { Switch, Route } from "react-router-dom";
 import Splash from "../pages/Splash";
 import Routes from "../routes/routes";
 
-const Layout: React.FunctionComponent = () => {
+const Layout: React.FC = () => {
     // eslint-disable-next-line
     const getRoutes = (routes: any): ReactNode => {
         // eslint-disable-next-line

--- a/src/components/SocialMedia.tsx
+++ b/src/components/SocialMedia.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const SocialMedia = () => {
+export const SocialMedia: React.FunctionComponent = () => {
     return (
         <div className="social">
             <ul className="social__list">

--- a/src/components/SocialMedia.tsx
+++ b/src/components/SocialMedia.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const SocialMedia: React.FunctionComponent = () => {
+export const SocialMedia: React.FC = () => {
     return (
         <div className="social">
             <ul className="social__list">

--- a/src/pages/HomeScreen/index.tsx
+++ b/src/pages/HomeScreen/index.tsx
@@ -12,11 +12,11 @@ import { useHistory } from "react-router-dom";
 const LoginMain = (): ReactElement => {
     const history = useHistory();
 
-    const handleGoToMovilAuth = () => {
+    const handleGoToMovilAuth = (): void => {
         history.push("/movil-auth/useId");
     };
 
-    const handleGoToRegister = () => {
+    const handleGoToRegister = (): void => {
         history.push("/Register");
     };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Login = () => {
+const Login: React.FunctionComponent = () => {
     return <>Login</>;
 };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Login: React.FunctionComponent = () => {
+const Login: React.FC = () => {
     return <>Login</>;
 };
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const NotFound: React.FunctionComponent = () => {
+const NotFound: React.FC = () => {
     return <div>NotFound</div>;
 };
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const NotFound = () => {
+const NotFound: React.FunctionComponent = () => {
     return <div>NotFound</div>;
 };
 

--- a/src/pages/Splash/index.tsx
+++ b/src/pages/Splash/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Logo from "../../img/Logo.svg";
 import { StyledContainer, StyledImg, StyledParagraph } from "./styles";
 
-const Splash = () => {
+const Splash: React.FunctionComponent = () => {
     return (
         <StyledContainer>
             <div>

--- a/src/pages/Splash/index.tsx
+++ b/src/pages/Splash/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Logo from "../../img/Logo.svg";
 import { StyledContainer, StyledImg, StyledParagraph } from "./styles";
 
-const Splash: React.FunctionComponent = () => {
+const Splash: React.FC = () => {
     return (
         <StyledContainer>
             <div>

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -7,7 +7,7 @@ import PrivateRoute from "./PrivateRoute";
 const Login = React.lazy(() => import("../pages/Login"));
 const index = React.lazy(() => import("../pages/HomeScreen"));
 
-const AppRouter: React.FunctionComponent = () => {
+const AppRouter: React.FC = () => {
     return (
         <>
             <Suspense fallback={Splash}>

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -7,7 +7,7 @@ import PrivateRoute from "./PrivateRoute";
 const Login = React.lazy(() => import("../pages/Login"));
 const index = React.lazy(() => import("../pages/HomeScreen"));
 
-const AppRouter = () => {
+const AppRouter: React.FunctionComponent = () => {
     return (
         <>
             <Suspense fallback={Splash}>
@@ -15,7 +15,7 @@ const AppRouter = () => {
                     <Switch>
                         <Route component={Login} path="/login" />
                         <Route component={index} path="/homescreen" />
-                        <PrivateRoute path="/">
+                        <PrivateRoute>
                             <Layout />
                         </PrivateRoute>
                     </Switch>

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Redirect, Route, RouteProps } from "react-router-dom";
 
-const PrivateRoute: React.FunctionComponent = ({ children, ...rest }: RouteProps) => {
+const PrivateRoute: React.FC = ({ children, ...rest }: RouteProps) => {
+    // eslint-disable-next-line
     const someLoginValidation = () => true;
 
     return (
         <Route
             {...rest}
+            // eslint-disable-next-line
             render={() => (someLoginValidation() ? children : <Redirect to="/login" />)}
         />
     );

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,13 +1,15 @@
-import React, { useContext } from "react";
+import React from "react";
 import { Redirect, Route, RouteProps } from "react-router-dom";
 
-export default function PrivateRoute({ children, ...rest }: RouteProps) {
+const PrivateRoute: React.FunctionComponent = ({ children, ...rest }: RouteProps) => {
     const someLoginValidation = () => true;
 
     return (
         <Route
             {...rest}
-            render={({ location }) => (someLoginValidation() ? children : <Redirect to="/login" />)}
+            render={() => (someLoginValidation() ? children : <Redirect to="/login" />)}
         />
     );
-}
+};
+
+export default PrivateRoute;


### PR DESCRIPTION
**3 nuevas reglas agregadas al linter!!**

1) explicit-module-boundary-types: exige que le coloques a los componentes que son un componente funcional de React, ejemplo:
![image](https://user-images.githubusercontent.com/47753872/108015473-19769200-6fef-11eb-9c70-dbfa9bee1d33.png)

2) no-unused-vars: revisa que no hayan variables declaradas o imports sin uso, ejemplo de uno que fue eliminado:
![image](https://user-images.githubusercontent.com/47753872/108015629-65c1d200-6fef-11eb-993e-79b60876ca22.png)

3) no-explicit-any: no permite que usemos type: any, si no que le definamos el tipo, en este caso lo corregí agregando una interface:
![image](https://user-images.githubusercontent.com/47753872/108015698-91dd5300-6fef-11eb-9d37-5d93e463ddc6.png)

Hay un componente, el Layout, donde deshabilité esta regla, ya que además de q no sabía cómo arreglar el error, vi que Agustín en su PR reciente de cambios en las rutas, eliminó este archivo por completo, asíque luego de que aprobemos su PR, este componente va a ser boleta :D
![image](https://user-images.githubusercontent.com/47753872/108015774-bdf8d400-6fef-11eb-930c-9b6cdf94c304.png)

Si se les ocurre alguna otra regla que agregar, me chiflen porfa!


