### PR TITLE
Se agregaron dos nuevas reglas al linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     plugins: ["@typescript-eslint"],
     rules: {
         "react/jsx-sort-props": 2,
+        "no-console": 2,
         "prettier/prettier": ["error", {}, { usePrettierrc: true }], // Use our .prettierrc file as source
         "@typescript-eslint/explicit-module-boundary-types": ["error"],
         "@typescript-eslint/no-explicit-any": ["error"],
@@ -42,6 +43,17 @@ module.exports = {
                 allowHigherOrderFunctions: true,
                 allowDirectConstAssertionInArrowFunctions: true,
                 allowConciseArrowFunctionExpressionsStartingWithVoid: true
+            }
+        ],
+        "@typescript-eslint/naming-convention": [
+            "error",
+            {
+                selector: "interface",
+                format: ["PascalCase"],
+                custom: {
+                    regex: "^I[A-Z]",
+                    match: true
+                }
             }
         ]
     }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -47,9 +47,9 @@ const LoginPage: React.FC = () => {
     const loginButtonClicked = (): void => {
         if (usernameObj.valid && passwordObj.valid) {
             //do something with the form Data
-            console.log("clicked!!! The user and the password ARE valid");
+            alert("clicked!!! The user and the password ARE valid");
         } else {
-            return console.log("clicked!! The user OR the password IS NOT valid");
+            return alert("clicked!! The user OR the password IS NOT valid");
         }
     };
 


### PR DESCRIPTION
Se agregaron dos nuevas reglas al linter!!

Por un lado, ya no se permitirán console logs en el código. Por el otro, los nombres de las interface deberán comenzar con I (i mayúscula) al principio. Para esto, revisa que matchee con la expresión regex: "^I[A-Z]" y da el siguiente error:

![image](https://user-images.githubusercontent.com/47753872/110861387-ce256b80-829c-11eb-851c-da1699574008.png)

Con respecto al ordenamiento de las propiedades CSS, que implica la instalación de una librería aparte, se creó una nueva card en Trello.