### PR TITLE
Feature/mostrar splash al inicio

### DIFF
--- a/src/components/Filter/FilterTab/styles.tsx
+++ b/src/components/Filter/FilterTab/styles.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { theme, fontSizes } from "../../../common/styles/index";
+import { theme, fontSizes } from "../../../common/styles/variables";
 
 const StyledImg = styled.img`
     margin: 0 auto;

--- a/src/pages/Splash/index.tsx
+++ b/src/pages/Splash/index.tsx
@@ -1,10 +1,20 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { PATHS } from "../../routes/paths";
 import Logo from "../../assets/img/Logo.svg";
 import { StyledContainer, StyledImg, StyledParagraph } from "./styles";
 
 const Splash: React.FC = () => {
     const { t } = useTranslation();
+    const history = useHistory();
+
+    useEffect(() => {
+        setTimeout(() => {
+            history.push(PATHS.Home);
+        }, 3000);
+    }, []);
+
     return (
         <StyledContainer>
             <div>

--- a/src/routes/AppRouter/index.tsx
+++ b/src/routes/AppRouter/index.tsx
@@ -1,9 +1,9 @@
 import React, { Suspense } from "react";
-import { BrowserRouter as Router, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Redirect, Route, Switch } from "react-router-dom";
 
 import RouteItem from "../RouteItem";
 import ROUTES from "../routes";
-
+import { PATHS } from "../paths";
 import Splash from "../../pages/Splash";
 
 const AppRouter = (): JSX.Element => {
@@ -12,6 +12,9 @@ const AppRouter = (): JSX.Element => {
             <Suspense fallback={Splash}>
                 <Router>
                     <Switch>
+                        <Route exact path="/">
+                            <Redirect to={PATHS.Splash} />
+                        </Route>
                         {ROUTES.map((route) => (
                             <RouteItem
                                 component={route.component}

--- a/src/routes/AppRouter/index.tsx
+++ b/src/routes/AppRouter/index.tsx
@@ -1,9 +1,8 @@
 import React, { Suspense } from "react";
-import { BrowserRouter as Router, Redirect, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Switch } from "react-router-dom";
 
 import RouteItem from "../RouteItem";
 import ROUTES from "../routes";
-import { PATHS } from "../paths";
 import Splash from "../../pages/Splash";
 
 const AppRouter = (): JSX.Element => {
@@ -12,9 +11,6 @@ const AppRouter = (): JSX.Element => {
             <Suspense fallback={Splash}>
                 <Router>
                     <Switch>
-                        <Route exact path="/">
-                            <Redirect to={PATHS.Splash} />
-                        </Route>
                         {ROUTES.map((route) => (
                             <RouteItem
                                 component={route.component}

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -1,5 +1,5 @@
 export enum PATHS {
-    Splash = "/Splash",
+    Splash = "/",
     Home = "/home",
     Login = "/login",
     Messages = "/messages",


### PR DESCRIPTION
Ahora al iniciar la aplicación la ruta http://localhost:3000/ te redirige al splash, y luego de 3 segundos te redirige a la pantalla de pre login (la cual tiene los botones: registrarse e iniciar sesion.

![splashpage](https://user-images.githubusercontent.com/47753872/113523903-61428000-9581-11eb-9fa4-64eeab8412a5.gif)

Además corregí un import que tiraba error y no me estaba permitiendo correr la app.